### PR TITLE
Change clone URL to use HTTPS

### DIFF
--- a/docs/source/for_the_impatient.rst
+++ b/docs/source/for_the_impatient.rst
@@ -65,7 +65,7 @@ See :ref:`app_projectroles_integration` on other ways to get started with SODAR 
 
 .. code-block:: bash
 
-    $ git clone git@github.com:bihealth/sodar_django_site.git sodar_django_site
+    $ git clone https://github.com/bihealth/sodar_django_site.git  sodar_django_site
     $ cd sodar_django_site
 
 From here on, we assume that you are located (a) within the ``sodar_django_site`` directory and (b) have done ``source ~/miniconda3/bin/activate`` such that ``which python`` shows ``~/miniconda3/bin/python``.


### PR DESCRIPTION
Hello,
The SSH git clone URL for the example site doesn't work for people who don't have SSH login to Git set up:

```zsh
(sodar-core)
 Sun 23 Feb - 08:55  ~/code 
 @olgabot  git clone git@github.com:bihealth/sodar_django_site.git sodar_django_site
Cloning into 'sodar_django_site'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
(sodar-core)
 ✘  Sun 23 Feb - 08:55  ~/code 
 @olgabot  git clone https://github.com/bihealth/sodar_django_site.git                                               Cloning into 'sodar_django_site'...
remote: Enumerating objects: 47, done.
remote: Counting objects: 100% (47/47), done.
remote: Compressing objects: 100% (29/29), done.
remote: Total 351 (delta 20), reused 34 (delta 18), pack-reused 304
Receiving objects: 100% (351/351), 95.93 KiB | 2.91 MiB/s, done.
Resolving deltas: 100% (180/180), done.
```

This PR updates the `git clone` URL for the example site. Thanks!
Warmest,
Olga